### PR TITLE
タスク実行タイムアウト設定の見直しとタスク粒度ルール明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,13 @@ frontend/
 - Rust: f2a-backend と同じパターン (handler → service → DB)
 - Frontend: TypeScript strict, Tailwind CSS
 
+## タスク粒度ルール
+
+- **1タスク = 1PR**: 各タスクは1つのPRで完結する粒度にする
+- 複数PRが必要な規模のタスクは、事前に分割する
+- スキャン提案時・手動タスク作成時の両方でこのルールを適用
+- 背景: 3PR一括タスクが600sタイムアウトした反省（2026-03 Sprint）
+
 ## 環境変数
 
 - `DATABASE_URL` — PostgreSQL 接続文字列 (`postgres://ai_dev_team:...@localhost/ai_dev_team`)

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,5 +1,28 @@
 use std::env;
 
+/// タスク実行タイムアウト（秒）
+pub mod timeout {
+    // 分析・計画系（読み取り専用、比較的短い）
+    pub const HEARING_SECS: u64 = 300;         // 5分
+    pub const PLANNER_SECS: u64 = 300;         // 5分
+    pub const SCAN_SECS: u64 = 300;            // 5分
+    pub const SPRINT_PLANNING_SECS: u64 = 180; // 3分
+    pub const RETROSPECTIVE_SECS: u64 = 180;   // 3分（120→180に引き上げ）
+
+    // 実行系（コード変更あり、長め）
+    pub const CODER_SECS: u64 = 1200;          // 20分（1タスク=1PRで粒度が小さくなる前提）
+    pub const REVIEWER_SECS: u64 = 300;        // 5分
+    pub const TEST_SECS: u64 = 300;            // 5分
+    pub const QA_SECS: u64 = 600;              // 10分
+
+    // 修正系（レビュー/テスト指摘の修正）
+    pub const FIX_SECS: u64 = 600;             // 10分
+
+    // 特殊タスク
+    pub const INVESTIGATION_SECS: u64 = 600;   // 10分
+    pub const OPERATION_SECS: u64 = 600;       // 10分
+}
+
 #[derive(Clone, Debug)]
 pub struct Config {
     pub database_url: String,

--- a/backend/src/executor/pipeline.rs
+++ b/backend/src/executor/pipeline.rs
@@ -1,12 +1,63 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
+use crate::config::timeout;
 use crate::domains::executions::service as exec_service;
 use crate::domains::tasks::model::{HearingQuestion, TaskStatus};
 use crate::domains::tasks::service as task_service;
 use crate::ws::WsHub;
 use super::claude_cli;
+use super::claude_cli::ClaudeResult;
 use super::worktree;
+
+/// タイムアウト時に1回だけリトライする run_claude ラッパー
+async fn run_claude_with_retry(
+    prompt: &str,
+    working_dir: &str,
+    timeout_secs: u64,
+) -> Result<ClaudeResult, String> {
+    match claude_cli::run_claude(prompt, working_dir, timeout_secs).await {
+        Ok(r) => Ok(r),
+        Err(e) if e.contains("timed out") => {
+            tracing::warn!("Claude timed out, retrying once: {e}");
+            claude_cli::run_claude(prompt, working_dir, timeout_secs).await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// タイムアウト時に1回だけリトライする run_claude_autonomous ラッパー
+async fn run_claude_autonomous_with_retry(
+    prompt: &str,
+    working_dir: &str,
+    timeout_secs: u64,
+) -> Result<ClaudeResult, String> {
+    match claude_cli::run_claude_autonomous(prompt, working_dir, timeout_secs).await {
+        Ok(r) => Ok(r),
+        Err(e) if e.contains("timed out") => {
+            tracing::warn!("Claude autonomous timed out, retrying once: {e}");
+            claude_cli::run_claude_autonomous(prompt, working_dir, timeout_secs).await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// タイムアウト時に1回だけリトライする run_claude_with_mcp ラッパー
+async fn run_claude_with_mcp_with_retry(
+    prompt: &str,
+    working_dir: &str,
+    timeout_secs: u64,
+    mcp_config_path: &str,
+) -> Result<ClaudeResult, String> {
+    match claude_cli::run_claude_with_mcp(prompt, working_dir, timeout_secs, mcp_config_path).await {
+        Ok(r) => Ok(r),
+        Err(e) if e.contains("timed out") => {
+            tracing::warn!("Claude MCP timed out, retrying once: {e}");
+            claude_cli::run_claude_with_mcp(prompt, working_dir, timeout_secs, mcp_config_path).await
+        }
+        Err(e) => Err(e),
+    }
+}
 
 /// 既存の一括実行パイプライン (skip_hearing=true 時に使用)
 pub async fn run_pipeline(
@@ -65,7 +116,7 @@ pub async fn run_pipeline(
         3. 計画のみ出力し、コード変更は行わないでください"
     );
 
-    let plan_result = match claude_cli::run_claude(&planner_prompt, &wt_path, 300).await {
+    let plan_result = match run_claude_with_retry(&planner_prompt, &wt_path, timeout::PLANNER_SECS).await {
         Ok(r) => r,
         Err(e) => {
             fail_pipeline(pool, ws_hub, task_id, session_id, repo_path, &worktree_dir, &e).await;
@@ -162,7 +213,7 @@ pub async fn run_hearing_phase(
         6. 最大5問までにしてください"
     );
 
-    let result = match claude_cli::run_claude(&hearing_prompt, &wt_path, 300).await {
+    let result = match run_claude_with_retry(&hearing_prompt, &wt_path, timeout::HEARING_SECS).await {
         Ok(r) => r,
         Err(e) => {
             fail_pipeline(pool, ws_hub, task_id, session_id, repo_path, &worktree_dir, &e).await;
@@ -299,7 +350,7 @@ pub async fn run_planning_phase(
         ),
     };
 
-    let plan_result = match claude_cli::run_claude(&planner_prompt, &wt_path, 300).await {
+    let plan_result = match run_claude_with_retry(&planner_prompt, &wt_path, timeout::PLANNER_SECS).await {
         Ok(r) => r,
         Err(e) => {
             let worktree_dir = std::path::PathBuf::from(&wt_path);
@@ -436,7 +487,7 @@ async fn run_coder_to_pr(
         - 変更は最小限に留めてください"
     );
 
-    let coder_result = match claude_cli::run_claude_autonomous(&coder_prompt, wt_path, 1500).await {
+    let coder_result = match run_claude_autonomous_with_retry(&coder_prompt, wt_path, timeout::CODER_SECS).await {
         Ok(r) => r,
         Err(e) => {
             fail_pipeline(pool, ws_hub, task_id, session_id, repo_path, worktree_dir, &e).await;
@@ -472,7 +523,7 @@ async fn run_coder_to_pr(
                 - 最終行に必ず VERDICT: APPROVE または VERDICT: REQUEST_CHANGES を出力"
             );
 
-            let review = match claude_cli::run_claude(&reviewer_prompt, wt_path, 300).await {
+            let review = match run_claude_with_retry(&reviewer_prompt, wt_path, timeout::REVIEWER_SECS).await {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!("Reviewer failed: {e}");
@@ -494,7 +545,7 @@ async fn run_coder_to_pr(
                 "レビューで修正が指摘されました。以下のレビューコメントに基づいて修正してください:\n\n{}\n\n修正のみ行い、余計な変更はしないでください。",
                 review.stdout
             );
-            let _ = claude_cli::run_claude_autonomous(&fix_prompt, wt_path, 600).await;
+            let _ = run_claude_autonomous_with_retry(&fix_prompt, wt_path, timeout::FIX_SECS).await;
         }
     } else {
         log(pool, session_id, "reviewer", 1, "info", "Reviewer スキップ (improvement タイプ)").await;
@@ -514,7 +565,7 @@ async fn run_coder_to_pr(
                 - テスト結果を確認\n\
                 - 最終行に必ず VERDICT: PASS または VERDICT: FAIL を出力";
 
-            let test = match claude_cli::run_claude_autonomous(test_prompt, wt_path, 300).await {
+            let test = match run_claude_autonomous_with_retry(test_prompt, wt_path, timeout::TEST_SECS).await {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::warn!("Test failed: {e}");
@@ -537,7 +588,7 @@ async fn run_coder_to_pr(
                 "テストが失敗しました。以下のテスト出力に基づいて修正してください:\n\n{}\n\n修正のみ行い、余計な変更はしないでください。",
                 test.stdout
             );
-            let _ = claude_cli::run_claude_autonomous(&fix_prompt, wt_path, 600).await;
+            let _ = run_claude_autonomous_with_retry(&fix_prompt, wt_path, timeout::FIX_SECS).await;
         }
     } else {
         log(pool, session_id, "test", 1, "info", "Test スキップ (improvement タイプ)").await;
@@ -585,7 +636,7 @@ async fn run_coder_to_pr(
             for iteration in 1..=2 {
                 log(pool, session_id, "qa", iteration, "info", &format!("QA iteration {iteration}")).await;
 
-                let qa_result = match claude_cli::run_claude_with_mcp(&qa_prompt, wt_path, 600, &mcp_config_path).await {
+                let qa_result = match run_claude_with_mcp_with_retry(&qa_prompt, wt_path, timeout::QA_SECS, &mcp_config_path).await {
                     Ok(r) => r,
                     Err(e) => {
                         tracing::warn!("QA Agent failed: {e}");
@@ -617,7 +668,7 @@ async fn run_coder_to_pr(
                     "QA テストが失敗しました。以下の QA 結果に基づいて修正してください:\n\n{}\n\n修正のみ行い、余計な変更はしないでください。",
                     qa_result.stdout
                 );
-                let _ = claude_cli::run_claude_autonomous(&fix_prompt, wt_path, 600).await;
+                let _ = run_claude_autonomous_with_retry(&fix_prompt, wt_path, timeout::FIX_SECS).await;
             }
         } else {
             log(pool, session_id, "qa", 1, "info", "QA スキップ — フロントエンド変更なし").await;
@@ -695,7 +746,7 @@ async fn run_investigation(
         - 発見事項、推奨事項、次のアクションを明確に記載してください"
     );
 
-    let result = match claude_cli::run_claude(&investigation_prompt, wt_path, 600).await {
+    let result = match run_claude_with_retry(&investigation_prompt, wt_path, timeout::INVESTIGATION_SECS).await {
         Ok(r) => r,
         Err(e) => {
             fail_pipeline(pool, ws_hub, task_id, session_id, repo_path, worktree_dir, &e).await;
@@ -752,7 +803,7 @@ async fn run_operation(
         - コードの変更は行わないでください"
     );
 
-    let result = match claude_cli::run_claude_autonomous(&operation_prompt, wt_path, 600).await {
+    let result = match run_claude_autonomous_with_retry(&operation_prompt, wt_path, timeout::OPERATION_SECS).await {
         Ok(r) => r,
         Err(e) => {
             fail_pipeline(pool, ws_hub, task_id, session_id, repo_path, worktree_dir, &e).await;

--- a/backend/src/scanner/analyzer.rs
+++ b/backend/src/scanner/analyzer.rs
@@ -9,6 +9,7 @@ use crate::domains::scans::model::ScanAnalysisOutput;
 use crate::domains::scans::service as scan_service;
 use crate::domains::sprints::service as sprint_service;
 use crate::domains::tasks::model::TaskStatus;
+use crate::config::timeout;
 use crate::executor::claude_cli;
 use crate::github::GitHubClient;
 use crate::ws::WsHub;
@@ -97,7 +98,7 @@ async fn run_scan_inner(
         .and_then(|r| r.local_path.as_deref())
         .unwrap_or("/tmp");
 
-    let result = claude_cli::run_claude(&prompt, working_dir, 300)
+    let result = claude_cli::run_claude(&prompt, working_dir, timeout::SCAN_SECS)
         .await
         .map_err(|e| format!("Claude CLI error: {e}"))?;
 
@@ -221,7 +222,7 @@ async fn run_sprint_planning_inner(
     );
 
     let working_dir = "/tmp";
-    let result = claude_cli::run_claude(&prompt, working_dir, 180)
+    let result = claude_cli::run_claude(&prompt, working_dir, timeout::SPRINT_PLANNING_SECS)
         .await
         .map_err(|e| format!("Claude CLI error: {e}"))?;
 
@@ -467,7 +468,7 @@ async fn run_retrospective(
         task_results.join("\n"),
     );
 
-    let result = claude_cli::run_claude(&prompt, "/tmp", 120)
+    let result = claude_cli::run_claude(&prompt, "/tmp", timeout::RETROSPECTIVE_SECS)
         .await
         .map_err(|e| format!("Retrospective generation failed: {e}"))?;
 
@@ -667,6 +668,8 @@ fn build_scan_prompt(
 }}
 
 ルール:
+- **1タスク = 1PR**: タスクは1つのPRで完結する粒度にすること。複数PRが必要な規模のタスクは分割して提案する
+- 大きなリファクタリングや複数ファイルにまたがる変更も、論理的に独立した単位に分割する
 - ユーザーは Issue に簡単なバグ・改善を書いているので、それをタスク化する
 - 失敗パターンが繰り返されている場合、improvement タスクとして改善を提案
 - investigation は不明点の調査が必要な場合のみ


### PR DESCRIPTION
## タスク
タイムアウト値を見直し（現行600s→タスク種別ごとに適切な値を設定）、1タスク=1PRの粒度ルールをCLAUDE.mdに明文化する。前スプリントで3PR一括タスクが600sタイムアウトした反省を反映。

## 計画
全ファイルの分析が完了しました。以下が実装計画です。

---

# 実装計画: タスク実行タイムアウト設定の見直しとタスク粒度ルール明文化

## 現状のタイムアウト値（すべてハードコード）

| フェーズ | 現行値 | ファイル:行 |
|---------|--------|------------|
| Hearing | 300s | pipeline.rs:165 |
| Planner | 300s | pipeline.rs:68, 302 |
| Coder | 1500s | pipeline.rs:439 |
| Reviewer | 300s | pipeline.rs:475 |
| Reviewer修正 | 600s | pipeline.rs:497 |
| Test | 300s | pipeline.rs:517 |
| Test修正 | 600s | pipeline.rs:540 |
| QA | 600s | pipeline.rs:588 |
| QA修正 | 600s | pipeline.rs:620 |
| Investigation | 600s | pipeline.rs:698 |
| Operation | 600s | pipeline.rs:755 |
| Scan | 300s | analyzer.rs:100 |
| Sprint Planning | 180s | analyzer.rs:224 |
| Retrospective | 120s | analyzer.rs:470 |

## 変更ファイル一覧

### 1. `backend/src/config.rs` — タイムアウト定数の定義

フェーズごとのタイムアウト値を定数として定義:

```rust
/// タスク実行タイムアウト（秒）
pub mod timeout {
    // 分析・計画系（読み取り専用、比較的短い）
    pub const HEARING_SECS: u64 = 300;       // 5分
    pub const PLANNER_SECS: u64 = 300;       // 5分
    pub const SCAN_SECS: u64 = 300;          // 5分
    pub const SPRINT_PLANNING_SECS: u64 = 180; // 3分
    pub const RETROSPECTIVE_SECS: u64 = 180;   // 3分（120→180に引き上げ）

    // 実行系（コード変更あり、長め）
    pub const CODER_SECS: u64 = 1200;        // 20分（1500→1200に短縮、1タスク=1PRで粒度が小さくなる前提）
    pub const REVIEWER_SECS: u64 = 300;      // 5分
    pub const TEST_SECS: u64 = 300;          // 5分
    pub const QA_SECS: u64 = 600;            // 10分

    // 修正系（レビュー/テスト指摘の修正）
    pub const FIX_SECS: u64 = 600;           // 10分

    // 特殊タスク
    pub const INVESTIGATION_SECS: u64 = 600; // 10分
    pub const OPERATION_SECS: u64 = 600;     // 10分
}
```

### 2. `backend/src/executor/pipeline.rs` — タイムアウト定数の適用 + リトライロジック追加

**変更内容:**
- 全 `claude_cli::run_claude*` 呼び出しのハードコード値を `config::timeout::*` 定数に置換
- タイムアウト時に **1回だけ自動リトライ** するヘルパー関数を追加

リトライロジック:
```rust
/// タイムアウト時に1回だけリトライする run_claude ラッパー
async fn run_claude_with_retry(
    prompt: &str,
    working_dir: &str,
    timeout_secs: u64,
) -> Result<ClaudeResult, String> {
    match claude_cli::run_claude(prompt, working_dir, timeout_secs).await {
        Ok(r) => Ok(r),
        Err(e) if e.contains("timed out") => {
            tracing::warn!("Claude timed out, retrying once: {e}");
            claude_cli::run_claude(prompt, working_dir, timeout_secs).await
        }
        Err(e) => Err(e),
    }
}
```

同様に `run_claude_autonomous_with_retry` と `run_claude_with_mcp_with_retry` も追加。

**置換箇所:**
- L68: `300` → `timeout::PLANNER_SECS`
- L165: `300` → `timeout::HEARING_SECS`
- L302: `300` → `timeout::PLANNER_SECS`
- L439: `1500` → `timeout::CODER_SECS` + リトライ
- L475: `300` → `timeout::REVIEWER_SECS`
- L497: `600` → `timeout::FIX_SECS`
- L517: `300` → `timeout::TEST_SECS`
- L540: `600` → `timeout::FIX_SECS`
- L588: `600` → `timeout::QA_SECS` + リトライ
- L620: `600` → `timeout::FIX_SECS`
- L698: `600` → `timeout::INVESTIGATION_SECS`
- L755: `600` → `timeout::OPERATION_SECS`

### 3. `backend/src/scanner/analyzer.rs` — タイムアウト定数の適用 + スキャンプロンプト改修

**タイムアウト置換:**
- L100: `300` → `timeout::SCAN_SECS`
- L224: `180` → `timeout::SPRINT_PLANNING_SECS`
- L470: `120` → `timeout::RETROSPECTIVE_SECS`

**スキャンプロンプトにタスク粒度ルール追記** (`build_scan_prompt` 関数内、L632付近):

`ルール:` セクションに以下を追加:
```
- **1タスク = 1PR**: タスクは1つのPRで完結する粒度にすること。複数PRが必要な規模のタスクは分割して提案する
- 大きなリファクタリングや複数ファイルにまたがる変更も、論理的に独立した単位に分割する
```

### 4. `CLAUDE.md`（プロジェクトルート） — タスク粒度ルールの明文化

`## コーディング規約` セクションの後に以下を追加:

```markdown
## タスク粒度ルール

- **1タスク = 1PR**: 各タスクは1つのPRで完結する粒度にする
- 複数PRが必要な規模のタスクは、事前に分割する
- スキャン提案時・手動タスク作成時の両方でこのルールを適用
- 背景: 3PR一括タスクが600sタイムアウトした反省（2026-03 Sprint）
```

## テスト方針

1. **コンパイル確認**: `cargo build` で定数参照・リトライ関数のコンパイルが通ることを確認
2. **単体テスト**: `run_claude_with_retry` のリトライロジックをテスト（タイムアウトエラー文字列でリトライ、それ以外はリトライしない）
3. **定数値の整合性確認**: `grep -rn` で pipeline.rs / analyzer.rs にハードコードのタイムアウト値が残っていないことを確認
4. **スキャンプロンプトの確認**: `build_scan_prompt` の出力に粒度ルールが含まれることを目視確認
