### PR TITLE
GitHub Branch Protection + Auto-merge 設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend (Rust)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: ai_dev_team
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: ai_dev_team
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://ai_dev_team:test@localhost:5432/ai_dev_team
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            backend/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('backend/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run migrations
+        run: |
+          for f in migrations/*.sql; do
+            psql "$DATABASE_URL" -f "$f"
+          done
+
+      - name: Build
+        run: cargo build
+
+      - name: Test
+        run: cargo test
+
+  frontend:
+    name: Frontend (Next.js)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/backend/src/executor/merger.rs
+++ b/backend/src/executor/merger.rs
@@ -9,12 +9,15 @@ use crate::executor::claude_cli;
 use crate::executor::worktree;
 use crate::ws::WsHub;
 
-const MERGE_CHECK_INTERVAL_SECS: u64 = 300; // 5分
+const CONFLICT_CHECK_INTERVAL_SECS: u64 = 300; // 5分
 
-/// 自動マージの定期ループを開始
-pub async fn start_auto_merge_loop(pool: PgPool, ws_hub: WsHub) {
+/// コンフリクト監視の定期ループを開始
+/// GitHub Auto-merge が有効な場合、マージ自体は GitHub が行う。
+/// このループはコンフリクト（CONFLICTING）で止まった PR を検出し、
+/// Claude Code で自動修復を試みる。
+pub async fn start_conflict_watch_loop(pool: PgPool, ws_hub: WsHub) {
     let mut interval =
-        tokio::time::interval(std::time::Duration::from_secs(MERGE_CHECK_INTERVAL_SECS));
+        tokio::time::interval(std::time::Duration::from_secs(CONFLICT_CHECK_INTERVAL_SECS));
 
     loop {
         interval.tick().await;
@@ -22,22 +25,22 @@ pub async fn start_auto_merge_loop(pool: PgPool, ws_hub: WsHub) {
         let tasks = match task_service::list_mergeable_tasks(&pool).await {
             Ok(tasks) => tasks,
             Err(e) => {
-                tracing::error!("自動マージ: タスク取得失敗: {e}");
+                tracing::error!("コンフリクト監視: タスク取得失敗: {e}");
                 continue;
             }
         };
 
         if tasks.is_empty() {
-            tracing::debug!("自動マージ: マージ対象なし");
+            tracing::debug!("コンフリクト監視: 監視対象なし");
             continue;
         }
 
-        tracing::info!("自動マージ: {} 件のPRをチェック", tasks.len());
+        tracing::info!("コンフリクト監視: {} 件のPRをチェック", tasks.len());
 
         for task in tasks {
             if let Err(e) = process_pr(&pool, &ws_hub, &task).await {
                 tracing::error!(
-                    "自動マージ: タスク {} ({}) の処理失敗: {e}",
+                    "コンフリクト監視: タスク {} ({}) の処理失敗: {e}",
                     task.id,
                     task.title
                 );
@@ -46,7 +49,8 @@ pub async fn start_auto_merge_loop(pool: PgPool, ws_hub: WsHub) {
     }
 }
 
-/// PR の状態をチェックし、マージ可能ならマージする
+/// PR の状態をチェックし、コンフリクトがあれば自動修復を試みる
+/// マージ自体は GitHub Auto-merge が行うため、このループではマージしない。
 async fn process_pr(pool: &PgPool, ws_hub: &WsHub, task: &Task) -> Result<(), String> {
     let pr_url = task
         .pr_url
@@ -70,14 +74,14 @@ async fn process_pr(pool: &PgPool, ws_hub: &WsHub, task: &Task) -> Result<(), St
 
     match pr_info.state.as_str() {
         "MERGED" => {
-            // 既にマージ済み
+            // 既にマージ済み（GitHub Auto-merge によるマージ完了）
             task_service::update_merge_status(pool, task.id, "merged")
                 .await
                 .map_err(|e| format!("状態更新失敗: {e}"))?;
-            task_service::add_merge_log(pool, task.id, "check", true, Some("既にマージ済み"))
+            task_service::add_merge_log(pool, task.id, "check", true, Some("GitHub Auto-mergeでマージ済み"))
                 .await
                 .ok();
-            notify_merge_event(ws_hub, task, "merged", "PRは既にマージされています");
+            notify_merge_event(ws_hub, task, "merged", "PRはGitHub Auto-mergeでマージされました");
             return Ok(());
         }
         "CLOSED" => {
@@ -90,37 +94,13 @@ async fn process_pr(pool: &PgPool, ws_hub: &WsHub, task: &Task) -> Result<(), St
             notify_merge_event(ws_hub, task, "failed", "PRがクローズされています");
             return Ok(());
         }
-        _ => {} // OPEN — 処理続行
+        _ => {} // OPEN — コンフリクトチェック続行
     }
 
-    // CI ステータスチェック
-    match pr_info.ci_status.as_str() {
-        "PENDING" | "EXPECTED" => {
-            // CI 未完了 → スキップ
-            tracing::debug!(
-                "自動マージ: PR #{pr_number} ({}) のCIが未完了、次回再チェック",
-                task.title
-            );
-            return Ok(());
-        }
-        "FAILURE" | "ERROR" => {
-            task_service::update_merge_status(pool, task.id, "failed")
-                .await
-                .map_err(|e| format!("状態更新失敗: {e}"))?;
-            task_service::add_merge_log(pool, task.id, "check", false, Some("CI失敗"))
-                .await
-                .ok();
-            notify_merge_event(ws_hub, task, "failed", "CIが失敗しています");
-            return Ok(());
-        }
-        _ => {} // SUCCESS or no checks
-    }
-
-    // マージ可能性チェック
+    // コンフリクトチェック（GitHub Auto-merge はコンフリクトがあると止まる）
     if pr_info.mergeable == "CONFLICTING" {
-        // コンフリクトあり → 自動修復を試みる
         tracing::info!(
-            "自動マージ: PR #{pr_number} ({}) にコンフリクト、修復を試みます",
+            "コンフリクト監視: PR #{pr_number} ({}) にコンフリクト、修復を試みます",
             task.title
         );
         task_service::update_merge_status(pool, task.id, "conflict")
@@ -128,70 +108,16 @@ async fn process_pr(pool: &PgPool, ws_hub: &WsHub, task: &Task) -> Result<(), St
             .map_err(|e| format!("状態更新失敗: {e}"))?;
         notify_merge_event(ws_hub, task, "conflict", "コンフリクトを検出、自動修復を試みています");
 
-        return resolve_conflict(pool, ws_hub, task, &repo_nwo, pr_number, &pr_info.head_ref).await;
+        return resolve_conflict(pool, ws_hub, task, &pr_info.head_ref).await;
     }
 
-    if pr_info.mergeable == "UNKNOWN" {
-        // GitHub がまだマージ可能性を計算中 → 次回再チェック
-        tracing::debug!(
-            "自動マージ: PR #{pr_number} ({}) のマージ可能性が未計算",
-            task.title
-        );
-        return Ok(());
-    }
-
-    // マージ可能（MERGEABLE）→ スカッシュマージ
-    attempt_merge(pool, ws_hub, task, &repo_nwo, pr_number).await
-}
-
-/// スカッシュマージを実行
-async fn attempt_merge(
-    pool: &PgPool,
-    ws_hub: &WsHub,
-    task: &Task,
-    repo_nwo: &str,
-    pr_number: u64,
-) -> Result<(), String> {
-    tracing::info!(
-        "自動マージ: PR #{pr_number} ({}) をスカッシュマージ",
-        task.title
+    // MERGEABLE or UNKNOWN → GitHub Auto-merge に任せる
+    tracing::debug!(
+        "コンフリクト監視: PR #{pr_number} ({}) は正常 (mergeable={})",
+        task.title,
+        pr_info.mergeable
     );
-
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "merge",
-            &pr_number.to_string(),
-            "--squash",
-            "--delete-branch",
-            "--repo",
-            repo_nwo,
-        ])
-        .output()
-        .await
-        .map_err(|e| format!("gh pr merge 実行失敗: {e}"))?;
-
-    if output.status.success() {
-        task_service::update_merge_status(pool, task.id, "merged")
-            .await
-            .map_err(|e| format!("状態更新失敗: {e}"))?;
-        task_service::add_merge_log(pool, task.id, "merge", true, Some("スカッシュマージ成功"))
-            .await
-            .ok();
-        notify_merge_event(ws_hub, task, "merged", "PRをスカッシュマージしました");
-        Ok(())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let msg = format!("マージ失敗: {stderr}");
-        task_service::update_merge_status(pool, task.id, "failed")
-            .await
-            .map_err(|e| format!("状態更新失敗: {e}"))?;
-        task_service::add_merge_log(pool, task.id, "merge", false, Some(&msg))
-            .await
-            .ok();
-        notify_merge_event(ws_hub, task, "failed", &msg);
-        Err(msg)
-    }
+    Ok(())
 }
 
 /// コンフリクトを Claude Code で解消
@@ -199,8 +125,6 @@ async fn resolve_conflict(
     pool: &PgPool,
     ws_hub: &WsHub,
     task: &Task,
-    repo_nwo: &str,
-    pr_number: u64,
     head_ref: &str,
 ) -> Result<(), String> {
     task_service::add_merge_log(
@@ -318,8 +242,15 @@ async fn resolve_conflict(
 
         if push.status.success() {
             worktree::cleanup_worktree(&repo_path, &worktree_dir).await.ok();
-            // マージ再試行
-            return attempt_merge(pool, ws_hub, task, repo_nwo, pr_number).await;
+            // コンフリクト解消済み → pending に戻して GitHub Auto-merge に任せる
+            task_service::update_merge_status(pool, task.id, "pending")
+                .await
+                .map_err(|e| format!("状態更新失敗: {e}"))?;
+            task_service::add_merge_log(pool, task.id, "resolve_conflict", true, Some("コンフリクト解消済み、Auto-mergeに委譲"))
+                .await
+                .ok();
+            notify_merge_event(ws_hub, task, "conflict_resolved", "コンフリクトを解消しました。GitHub Auto-mergeでマージされます。");
+            return Ok(());
         }
     }
 
@@ -475,6 +406,7 @@ fn extract_repo_nwo(pr_url: &str) -> Option<String> {
 struct PrInfo {
     state: String,
     mergeable: String,
+    #[allow(dead_code)] // CI ステータスはログ・将来の拡張用に保持
     ci_status: String,
     head_ref: String,
 }

--- a/backend/src/executor/worktree.rs
+++ b/backend/src/executor/worktree.rs
@@ -161,6 +161,37 @@ pub async fn commit_and_create_pr(
     }
 
     let pr_url = String::from_utf8_lossy(&pr.stdout).trim().to_string();
+
+    // GitHub Auto-merge を有効化（Branch Protection 未設定の場合は無視される）
+    let auto_merge = Command::new("gh")
+        .args([
+            "pr",
+            "merge",
+            &pr_url,
+            "--auto",
+            "--squash",
+            "--delete-branch",
+        ])
+        .current_dir(worktree_path)
+        .output()
+        .await;
+
+    match auto_merge {
+        Ok(output) if output.status.success() => {
+            tracing::info!("Auto-merge enabled for PR: {pr_url}");
+        }
+        Ok(output) => {
+            // auto-merge が有効化できなくても PR 作成自体は成功
+            tracing::warn!(
+                "Auto-merge could not be enabled (Branch Protection may not be configured): {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Err(e) => {
+            tracing::warn!("Failed to run gh pr merge --auto: {e}");
+        }
+    }
+
     Ok(pr_url)
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -297,12 +297,12 @@ async fn main() {
         });
     }
 
-    // 自動マージループ起動
+    // コンフリクト監視ループ起動（マージは GitHub Auto-merge が行う）
     {
         let merge_pool = state.pool.clone();
         let merge_ws = state.ws_hub.clone();
         tokio::spawn(async move {
-            executor::merger::start_auto_merge_loop(merge_pool, merge_ws).await;
+            executor::merger::start_conflict_watch_loop(merge_pool, merge_ws).await;
         });
     }
 

--- a/docs/branch-protection-setup.md
+++ b/docs/branch-protection-setup.md
@@ -1,0 +1,76 @@
+# Branch Protection + Auto-merge 設定手順
+
+ai-dev-team が管理する全プロジェクトリポジトリに対して、main ブランチの保護と Auto-merge を設定する手順。
+
+## 対象リポジトリ
+
+| リポジトリ | CI 内容 |
+|-----------|---------|
+| sode0417/ai-dev-team | cargo build + cargo test + npm run build |
+| sode0417/factrail | npm run build + npm run test |
+| sode0417/f2a-backend | cargo build + cargo test |
+| sode0417/f2a-frontend | npm run build |
+| sode0417/ai-assistant | Python lint + test |
+| sode0417/self-protocol | npm run build |
+| sode0417/slack-cli | cargo build + cargo test |
+
+## 手順 1: Auto-merge を有効化
+
+各リポジトリで以下を実施:
+
+1. GitHub リポジトリページ → **Settings** → **General**
+2. **Pull Requests** セクションまでスクロール
+3. **Allow auto-merge** にチェック → **Save**
+
+## 手順 2: CI ワークフローを追加
+
+各リポジトリに `.github/workflows/ci.yml` を追加する。
+
+- **ai-dev-team**: 本リポジトリの `.github/workflows/ci.yml` をそのまま使用
+- **その他のリポ**: `docs/ci-template.yml` をベースにカスタマイズ
+
+## 手順 3: Branch Protection Rule を設定
+
+各リポジトリで以下を実施:
+
+1. GitHub リポジトリページ → **Settings** → **Branches**
+2. **Add branch protection rule** をクリック
+3. 以下の値を設定:
+
+| 設定項目 | 値 |
+|---------|---|
+| Branch name pattern | `main` |
+| Require a pull request before merging | OFF |
+| Require status checks to pass before merging | ON |
+| Require branches to be up to date before merging | OFF（推奨: コンフリクト監視が自動解消するため） |
+| Status checks that are required | `Backend (Rust)`, `Frontend (Next.js)` ※リポによって異なる |
+| Require conversation resolution before merging | OFF |
+| Require signed commits | OFF |
+| Require linear history | OFF |
+| Include administrators | OFF（管理者は緊急マージ可能に） |
+| Restrict who can push to matching branches | OFF |
+| Allow force pushes | OFF |
+| Allow deletions | OFF |
+
+4. **Create** をクリック
+
+### 必須ステータスチェック名の確認方法
+
+Branch Protection の "Status checks that are required" に指定する名前は、CI ワークフローの `jobs.<job_id>.name` に対応する。
+
+- `Backend (Rust)` — ai-dev-team, f2a-backend, slack-cli
+- `Frontend (Next.js)` — ai-dev-team, f2a-frontend, factrail
+- リポによって異なるため、初回 PR で CI が実行された後に設定するのが確実
+
+## 手順 4: 動作確認
+
+1. テスト用ブランチを作成し、PR を作成
+2. CI が自動実行されることを確認
+3. `gh pr merge --auto --squash --delete-branch` で Auto-merge を有効化
+4. CI パス後に自動マージされることを確認
+
+## 注意事項
+
+- Branch Protection 未設定のリポでは `gh pr merge --auto` はエラーになるが、ai-dev-team の pipeline はこれを警告ログとして処理し、PR 作成自体は成功する
+- Auto-merge はコンフリクトがあると停止する。ai-dev-team のコンフリクト監視ループが自動修復を試みる
+- Required reviews は 0（不要）。bot が作成した PR を自動マージするため

--- a/docs/ci-template.yml
+++ b/docs/ci-template.yml
@@ -1,0 +1,119 @@
+# CI テンプレート
+# 各リポジトリの .github/workflows/ci.yml にコピーしてカスタマイズする
+#
+# カスタマイズポイント:
+# - Rust のみ: frontend ジョブを削除
+# - Node.js のみ: backend ジョブを削除
+# - Python: backend ジョブを Python 用に書き換え
+# - PostgreSQL 不要: services セクションを削除
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  # === Rust バックエンド ===
+  # 不要な場合はこのジョブごと削除
+  backend:
+    name: Backend (Rust)
+    runs-on: ubuntu-latest
+
+    # PostgreSQL が不要なら services セクションを削除
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: app_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://app:test@localhost:5432/app_test
+
+    # working-directory をリポ構成に合わせて変更
+    # モノレポでない場合は defaults セクションを削除
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            backend/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('backend/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      # マイグレーションがある場合
+      - name: Run migrations
+        run: |
+          for f in migrations/*.sql; do
+            psql "$DATABASE_URL" -f "$f"
+          done
+
+      - name: Build
+        run: cargo build
+
+      - name: Test
+        run: cargo test
+
+  # === Node.js フロントエンド ===
+  # 不要な場合はこのジョブごと削除
+  frontend:
+    name: Frontend (Next.js)
+    runs-on: ubuntu-latest
+
+    # working-directory をリポ構成に合わせて変更
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # テストがある場合
+      # - name: Test
+      #   run: npm test
+
+  # === Python ===
+  # Rust/Node.js の代わりに使う場合
+  # python:
+  #   name: Python
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.12"
+  #     - run: pip install -r requirements.txt
+  #     - run: python -m pytest

--- a/frontend/src/components/MergeNotification.tsx
+++ b/frontend/src/components/MergeNotification.tsx
@@ -92,6 +92,12 @@ const EVENT_STYLES: Record<
     icon: "text-gh-red",
     label: "マージ失敗",
   },
+  auto_merge_enabled: {
+    bg: "bg-gh-blue/10",
+    border: "border-gh-blue/30",
+    icon: "text-gh-blue",
+    label: "Auto-merge有効",
+  },
 };
 
 function NotificationToast({
@@ -114,6 +120,7 @@ function NotificationToast({
           {event.event === "conflict_resolved" && "\u2713"}
           {event.event === "conflict" && "\u26A0"}
           {event.event === "failed" && "\u2717"}
+          {event.event === "auto_merge_enabled" && "\u2713"}
         </span>
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between gap-2">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -258,7 +258,7 @@ export interface MergeEvent {
   type: "merge_event";
   task_id: string;
   task_title: string;
-  event: "merged" | "conflict_resolved" | "conflict" | "failed";
+  event: "merged" | "conflict_resolved" | "conflict" | "failed" | "auto_merge_enabled";
   message: string;
 }
 


### PR DESCRIPTION
## タスク
mainブランチにCI必須のブランチ保護ルールを設定し、CIパス後に自動マージされるようにする。ユーザーフィードバックで提案された改善で、マージ作業のボトルネックを根本解消する。

## 計画
十分な情報が揃いました。以下が実装計画です。

---

# 実装計画: GitHub Branch Protection + Auto-merge 設定

## 概要

3つの柱:
1. **GitHub Actions CI ワークフロー作成** — 管理対象リポジトリにテンプレートとして使えるCI定義
2. **PR作成時に `gh pr merge --auto` を実行** — GitHub Auto-merge を有効化
3. **merger.rs のポーリングループ廃止** — GitHub Auto-merge に移行するため不要に
4. **Branch Protection 設定手順書** — 手動設定用ドキュメント

## 変更ファイル一覧

### 1. `backend/src/executor/worktree.rs` — PR作成後に auto-merge 有効化

**変更内容:**
- `commit_and_create_pr()` 関数内で `gh pr create` 成功後に `gh pr merge --auto --squash --delete-branch` を実行
- PR URL を返す前に auto-merge を有効化。Branch Protection が未設定のリポでは auto-merge は無視されるだけなので安全

```
// 追加: gh pr create 成功後
gh pr merge <pr_url> --auto --squash --delete-branch
```

### 2. `backend/src/executor/merger.rs` — ポーリングループの廃止

**変更内容:**
- `start_auto_merge_loop()` を削除（またはコンフリクト解消機能のみ残す）
- ポーリングで CI チェック → マージの流れは GitHub Auto-merge が担うため不要
- **コンフリクト解消（`resolve_conflict()`）は残す**: Auto-merge が CONFLICTING で止まった場合に Claude Code で解消する機能は有用
- `process_pr()` を簡略化: マージ試行部分（`attempt_merge()`）を削除し、コンフリクト検出 + 解消のみに変更
- `attempt_merge()` 関数を削除

### 3. `backend/src/main.rs:300-307` — auto-merge ループの起動コード変更

**変更内容:**
- `start_auto_merge_loop` の呼び出しを、コンフリクト監視ループ（リネーム後）に変更
- コンフリクト解消の定期チェックは残す（GitHub Auto-merge が CONFLICTING で止まるケースへの対応）

### 4. `docs/branch-protection-setup.md` — 新規作成: Branch Protection 設定手順書

**変更内容:**
- 管理対象リポジトリ一覧（CLAUDE.md のプロジェクト一覧に基づく）
- GitHub Web UI での Branch Protection 設定手順:
  - Settings → Branches → Add rule
  - Branch name pattern: `main`
  - Require status checks to pass: 有効
  - 必須チェック: `ci` (ワークフロー名)
  - Required reviews: 0（不要）
  - Allow auto-merge: 有効化（Settings → General → Allow auto-merge）
- スクリーンショット代わりの設定値一覧

### 5. `.github/workflows/ci.yml` — 新規作成: ai-dev-team 用 CI ワークフロー

**変更内容:**
```yaml
name: CI
on:
  pull_request:
    branches: [main]
jobs:
  backend:
    runs-on: ubuntu-latest
    services:
      postgres: ...
    steps:
      - checkout
      - rust toolchain setup
      - cargo build
      - cargo test
  frontend:
    runs-on: ubuntu-latest
    steps:
      - checkout
      - node setup
      - npm ci
      - npm run build
```

### 6. `docs/ci-template.yml` — 新規作成: 他リポ用 CI テンプレート

**変更内容:**
- 各リポジトリに適用可能な CI テンプレート
- リポごとのカスタマイズポイントをコメントで記載（Rust only / Node only / 両方）

### 7. `frontend/src/components/MergeNotification.tsx` — 軽微な表示調整

**変更内容:**
- `auto_merge_enabled` イベントに対応する表示を追加（PR 作成時に auto-merge が有効化されたことの通知）

### 8. `frontend/src/types/index.ts` — 型定義追加

**変更内容:**
- MergeEvent の event 型に `"auto_merge_enabled"` を追加（該当する型がある場合）

## 変更しないもの

- `resolve_conflict()` — コンフリクト解消ロジックは引き続き必要（Auto-merge はコンフリクトがあると止まるため）
- `merge_logs` テーブル / `list_mergeable_tasks()` / `update_merge_status()` / `add_merge_log()` — コンフリクト監視で引き続き使用
- DB マイグレーション — 既存の `merge_status` カラム等はそのまま活用

## テスト方針

1. **`cargo build`** — コンパイルエラーがないことを確認
2. **`cargo test`** — merger.rs の既存テスト（`extract_pr_number`, `extract_repo_nwo`, `aggregate_ci_status`）が引き続きパス
3. **`npm run build`** — フロントエンドビルド成功確認
4. **手動テスト**: ai-dev-team リポで実際に PR を作成し、auto-merge フラグが付くことを確認
5. **CI ワークフロー**: PR 上で GitHub Actions が実行されることを確認

## 実装順序

1. `.github/workflows/ci.yml` 作成（CI を先に用意）
2. `worktree.rs` に auto-merge 有効化を追加
3. `merger.rs` のポーリング→コンフリクト監視に簡略化
4. `main.rs` のループ起動コード修正
5. フロントエンド通知対応
6. `docs/branch-protection-setup.md` + `docs/ci-template.yml` 作成
7. ビルド・テスト確認
