### PR TITLE
タスク定義に完了条件(Definition of Done)を必須化（再実行）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ psql -U ai_dev_team -d ai_dev_team -f backend/migrations/20260319100000_users.sq
 psql -U ai_dev_team -d ai_dev_team -f backend/migrations/20260320000000_improving_phase.sql
 psql -U ai_dev_team -d ai_dev_team -f backend/migrations/20260320000000_revision_flow.sql
 psql -U ai_dev_team -d ai_dev_team -f backend/migrations/20260320100000_auto_merge.sql
+psql -U ai_dev_team -d ai_dev_team -f backend/migrations/20260321000000_definition_of_done.sql
 
 # 認証セットアップ（任意）
 # 1. .env に AUTH_ENABLED=true と JWT_SECRET を設定

--- a/backend/migrations/20260321000000_definition_of_done.sql
+++ b/backend/migrations/20260321000000_definition_of_done.sql
@@ -1,0 +1,2 @@
+-- タスクに完了条件 (Definition of Done) カラムを追加
+ALTER TABLE tasks ADD COLUMN definition_of_done TEXT;

--- a/backend/src/domains/scans/model.rs
+++ b/backend/src/domains/scans/model.rs
@@ -36,6 +36,7 @@ pub struct TaskProposal {
     pub priority: Option<String>,
     pub proposal_type: Option<String>,
     pub issue_number: Option<i64>,
+    pub definition_of_done: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/backend/src/domains/scans/service.rs
+++ b/backend/src/domains/scans/service.rs
@@ -11,7 +11,7 @@ const SCAN_COLS: &str = "id, project_id, status, analysis, priority_actions, \
 const TASK_COLS: &str = "id, project_id, repository_id, title, description, status, priority, \
     depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
     retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, \
-    scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count";
+    scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done";
 
 pub async fn create_scan(pool: &PgPool, project_id: Uuid) -> Result<ScanSession, AppError> {
     let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM projects WHERE id = $1)")
@@ -151,8 +151,8 @@ pub async fn create_tasks_from_proposals(
             &format!(
                 "INSERT INTO tasks \
                     (project_id, repository_id, title, description, priority, \
-                     proposed_by, execution_order, scan_id, proposal_type, sprint_id) \
-                 VALUES ($1, $2, $3, $4, $5, 'scan', $6, $7, $8, $9) \
+                     proposed_by, execution_order, scan_id, proposal_type, sprint_id, definition_of_done) \
+                 VALUES ($1, $2, $3, $4, $5, 'scan', $6, $7, $8, $9, $10) \
                  RETURNING {TASK_COLS}"
             ),
         )
@@ -165,6 +165,7 @@ pub async fn create_tasks_from_proposals(
         .bind(scan_id)
         .bind(proposal_type)
         .bind(sprint_id)
+        .bind(&proposal.definition_of_done)
         .fetch_one(pool)
         .await?;
 

--- a/backend/src/domains/tasks/handler.rs
+++ b/backend/src/domains/tasks/handler.rs
@@ -10,6 +10,65 @@ use crate::response::SuccessResponse;
 use super::model::*;
 use super::service;
 
+/// Issue 本文から Definition of Done (完了条件) を自動抽出する
+fn extract_dod_from_issue(title: &str, body: &str) -> String {
+    // セクションヘッダーを探す
+    let section_markers = [
+        "## Definition of Done",
+        "## DoD",
+        "## 完了条件",
+        "## Acceptance Criteria",
+        "### Definition of Done",
+        "### DoD",
+        "### 完了条件",
+        "### Acceptance Criteria",
+    ];
+
+    for marker in &section_markers {
+        if let Some(start) = body.find(marker) {
+            let after = &body[start + marker.len()..];
+            // 次のセクション（## or ###）までを取得
+            let section = if let Some(end) = after[1..].find("\n## ").or_else(|| after[1..].find("\n### ")) {
+                &after[..end + 1]
+            } else {
+                after
+            };
+            let items = extract_checklist_items(section);
+            if !items.is_empty() {
+                return items.join("\n");
+            }
+        }
+    }
+
+    // セクションが見つからない場合、本文全体からチェックリスト形式を探す
+    let items = extract_checklist_items(body);
+    if !items.is_empty() {
+        return items.join("\n");
+    }
+
+    // フォールバック: Issue タイトルから生成
+    format!("- [ ] {} が実装されている\n- [ ] テストが通る\n- [ ] ビルドが成功する", title)
+}
+
+/// テキストからチェックリスト項目（`- [ ]` / `- [x]`）を抽出
+fn extract_checklist_items(text: &str) -> Vec<String> {
+    text.lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            trimmed.starts_with("- [ ]") || trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]")
+        })
+        .map(|line| {
+            // 全てを未チェック状態に統一
+            let trimmed = line.trim();
+            if trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]") {
+                format!("- [ ]{}", &trimmed[5..])
+            } else {
+                trimmed.to_string()
+            }
+        })
+        .collect()
+}
+
 async fn list_tasks(
     State(state): State<AppState>,
     _auth: AuthUser,
@@ -341,12 +400,18 @@ async fn execute_issue(
     let issue = state.github.fetch_issue(&repo.owner, &repo.name, body.issue_number as i64).await?;
 
     // Issue からタスクを作成
+    let issue_body = issue.body.unwrap_or_default();
     let description = format!(
         "GitHub Issue #{}: {}\n\n{}",
         issue.number,
         issue.title,
-        issue.body.unwrap_or_default()
+        issue_body
     );
+
+    // DoD: リクエストで明示指定があればそれを使用、なければ Issue 本文から自動抽出
+    let definition_of_done = body.definition_of_done.clone()
+        .unwrap_or_else(|| extract_dod_from_issue(&issue.title, &issue_body));
+
     let task = service::create_task_from_issue(
         &state.pool,
         body.project_id,
@@ -355,6 +420,7 @@ async fn execute_issue(
         &body.issue_url,
         &issue.title,
         &description,
+        &definition_of_done,
     ).await?;
 
     let task_id = task.id;

--- a/backend/src/domains/tasks/model.rs
+++ b/backend/src/domains/tasks/model.rs
@@ -63,6 +63,7 @@ pub struct Task {
     pub merge_status: Option<String>,
     pub merge_attempted_at: Option<DateTime<Utc>>,
     pub revision_count: i32,
+    pub definition_of_done: Option<String>,
 }
 
 #[derive(Debug, Serialize, sqlx::FromRow)]
@@ -82,6 +83,7 @@ pub struct CreateTaskRequest {
     pub title: String,
     pub description: String,
     pub priority: Option<TaskPriority>,
+    pub definition_of_done: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -89,6 +91,7 @@ pub struct UpdateTaskRequest {
     pub title: Option<String>,
     pub description: Option<String>,
     pub priority: Option<TaskPriority>,
+    pub definition_of_done: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -144,6 +147,7 @@ pub struct ExecuteIssueRequest {
     pub issue_number: i32,
     pub issue_url: String,
     pub skip_hearing: Option<bool>,
+    pub definition_of_done: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/backend/src/domains/tasks/service.rs
+++ b/backend/src/domains/tasks/service.rs
@@ -9,7 +9,7 @@ pub async fn list_tasks(pool: &PgPool, query: &ListTasksQuery) -> Result<Vec<Tas
     let mut sql = String::from(
         "SELECT id, project_id, repository_id, title, description, status, priority, \
          depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
-         retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count \
+         retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done \
          FROM tasks WHERE 1=1",
     );
     let mut binds: Vec<String> = vec![];
@@ -31,7 +31,7 @@ pub async fn list_tasks(pool: &PgPool, query: &ListTasksQuery) -> Result<Vec<Tas
             Ok(sqlx::query_as::<_, Task>(
                 "SELECT id, project_id, repository_id, title, description, status, priority, \
                  depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
-                 retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count \
+                 retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done \
                  FROM tasks WHERE project_id = $1 AND status::text = $2 \
                  ORDER BY execution_order, created_at DESC",
             )
@@ -44,7 +44,7 @@ pub async fn list_tasks(pool: &PgPool, query: &ListTasksQuery) -> Result<Vec<Tas
             Ok(sqlx::query_as::<_, Task>(
                 "SELECT id, project_id, repository_id, title, description, status, priority, \
                  depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
-                 retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count \
+                 retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done \
                  FROM tasks WHERE project_id = $1 \
                  ORDER BY execution_order, created_at DESC",
             )
@@ -56,7 +56,7 @@ pub async fn list_tasks(pool: &PgPool, query: &ListTasksQuery) -> Result<Vec<Tas
             Ok(sqlx::query_as::<_, Task>(
                 "SELECT id, project_id, repository_id, title, description, status, priority, \
                  depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
-                 retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count \
+                 retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done \
                  FROM tasks WHERE status::text = $1 \
                  ORDER BY execution_order, created_at DESC",
             )
@@ -68,7 +68,7 @@ pub async fn list_tasks(pool: &PgPool, query: &ListTasksQuery) -> Result<Vec<Tas
             Ok(sqlx::query_as::<_, Task>(
                 "SELECT id, project_id, repository_id, title, description, status, priority, \
                  depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
-                 retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count \
+                 retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done \
                  FROM tasks ORDER BY execution_order, created_at DESC",
             )
             .fetch_all(pool)
@@ -81,7 +81,7 @@ pub async fn get_task(pool: &PgPool, id: Uuid) -> Result<Task, AppError> {
     sqlx::query_as::<_, Task>(
         "SELECT id, project_id, repository_id, title, description, status, priority, \
          depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
-         retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count \
+         retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done \
          FROM tasks WHERE id = $1",
     )
     .bind(id)
@@ -103,17 +103,18 @@ pub async fn create_task(pool: &PgPool, req: &CreateTaskRequest) -> Result<Task,
     let priority = req.priority.clone().unwrap_or(TaskPriority::Medium);
 
     sqlx::query_as::<_, Task>(
-        "INSERT INTO tasks (project_id, repository_id, title, description, priority) \
-         VALUES ($1, $2, $3, $4, $5) \
+        "INSERT INTO tasks (project_id, repository_id, title, description, priority, definition_of_done) \
+         VALUES ($1, $2, $3, $4, $5, $6) \
          RETURNING id, project_id, repository_id, title, description, status, priority, \
          depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
-         retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count",
+         retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done",
     )
     .bind(req.project_id)
     .bind(req.repository_id)
     .bind(&req.title)
     .bind(&req.description)
     .bind(&priority)
+    .bind(&req.definition_of_done)
     .fetch_one(pool)
     .await
     .map_err(AppError::from)
@@ -127,13 +128,14 @@ pub async fn create_task_from_issue(
     issue_url: &str,
     title: &str,
     description: &str,
+    definition_of_done: &str,
 ) -> Result<Task, AppError> {
     sqlx::query_as::<_, Task>(
-        "INSERT INTO tasks (project_id, repository_id, title, description, issue_number, issue_url, proposal_type) \
-         VALUES ($1, $2, $3, $4, $5, $6, 'development') \
+        "INSERT INTO tasks (project_id, repository_id, title, description, issue_number, issue_url, proposal_type, definition_of_done) \
+         VALUES ($1, $2, $3, $4, $5, $6, 'development', $7) \
          RETURNING id, project_id, repository_id, title, description, status, priority, \
          depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
-         retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count",
+         retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done",
     )
     .bind(project_id)
     .bind(repository_id)
@@ -141,6 +143,7 @@ pub async fn create_task_from_issue(
     .bind(description)
     .bind(issue_number)
     .bind(issue_url)
+    .bind(definition_of_done)
     .fetch_one(pool)
     .await
     .map_err(AppError::from)
@@ -152,16 +155,18 @@ pub async fn update_task(pool: &PgPool, id: Uuid, req: &UpdateTaskRequest) -> Re
             title = COALESCE($2, title),
             description = COALESCE($3, description),
             priority = COALESCE($4, priority),
+            definition_of_done = COALESCE($5, definition_of_done),
             updated_at = NOW()
         WHERE id = $1
         RETURNING id, project_id, repository_id, title, description, status, priority,
         depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats,
-        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count"#,
+        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done"#,
     )
     .bind(id)
     .bind(&req.title)
     .bind(&req.description)
     .bind(&req.priority)
+    .bind(&req.definition_of_done)
     .fetch_optional(pool)
     .await?
     .ok_or(AppError::NotFound)
@@ -181,7 +186,7 @@ pub async fn approve_task(pool: &PgPool, id: Uuid) -> Result<Task, AppError> {
         WHERE id = $1
         RETURNING id, project_id, repository_id, title, description, status, priority,
         depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats,
-        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count"#,
+        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done"#,
     )
     .bind(id)
     .fetch_one(pool)
@@ -200,7 +205,7 @@ pub async fn cancel_task(pool: &PgPool, id: Uuid) -> Result<Task, AppError> {
         WHERE id = $1
         RETURNING id, project_id, repository_id, title, description, status, priority,
         depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats,
-        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count"#,
+        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done"#,
     )
     .bind(id)
     .fetch_one(pool)
@@ -245,7 +250,7 @@ pub async fn update_task_execution(
         WHERE id = $1
         RETURNING id, project_id, repository_id, title, description, status, priority,
         depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats,
-        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count"#,
+        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done"#,
     )
     .bind(id)
     .bind(&status)
@@ -339,7 +344,7 @@ pub async fn approve_plan(pool: &PgPool, id: Uuid) -> Result<Task, AppError> {
         WHERE id = $1
         RETURNING id, project_id, repository_id, title, description, status, priority,
         depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats,
-        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count"#,
+        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done"#,
     )
     .bind(id)
     .fetch_one(pool)
@@ -364,7 +369,7 @@ pub async fn reject_plan(pool: &PgPool, id: Uuid, action: &str) -> Result<Task, 
         WHERE id = $1
         RETURNING id, project_id, repository_id, title, description, status, priority,
         depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats,
-        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count"#,
+        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done"#,
     )
     .bind(id)
     .bind(new_status)
@@ -381,7 +386,7 @@ pub async fn list_mergeable_tasks(pool: &PgPool) -> Result<Vec<Task>, AppError> 
         "SELECT id, project_id, repository_id, title, description, status, priority, \
          depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats, \
          retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, \
-         scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count \
+         scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done \
          FROM tasks WHERE pr_url IS NOT NULL AND status = 'completed' AND merge_status = 'pending' \
          ORDER BY completed_at",
     )
@@ -448,7 +453,7 @@ pub async fn request_revision(pool: &PgPool, id: Uuid) -> Result<Task, AppError>
         WHERE id = $1
         RETURNING id, project_id, repository_id, title, description, status, priority,
         depends_on, execution_order, execution_group, proposed_by, plan, pr_url, changed_files, diff_stats,
-        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count"#,
+        retry_count, max_retries, error_log, created_at, started_at, completed_at, updated_at, scan_id, proposal_type, sprint_id, issue_number, issue_url, merge_status, merge_attempted_at, revision_count, definition_of_done"#,
     )
     .bind(id)
     .fetch_one(pool)

--- a/backend/src/executor/pipeline.rs
+++ b/backend/src/executor/pipeline.rs
@@ -10,6 +10,16 @@ use super::claude_cli;
 use super::claude_cli::ClaudeResult;
 use super::worktree;
 
+/// DoD セクションを構築（プロンプト注入用）
+fn build_dod_section(definition_of_done: &Option<String>) -> String {
+    match definition_of_done {
+        Some(dod) if !dod.trim().is_empty() => {
+            format!("## 完了条件 (Definition of Done)\n{dod}\n\n")
+        }
+        _ => String::new(),
+    }
+}
+
 /// タイムアウト時に1回だけリトライする run_claude ラッパー
 async fn run_claude_with_retry(
     prompt: &str,
@@ -102,18 +112,25 @@ pub async fn run_pipeline(
     broadcast(ws_hub, task_id, "planning", "Planner Agent 起動中...").await;
     log(pool, session_id, "planner", 1, "info", "Planner Agent 開始").await;
 
+    // DoD 取得
+    let dod = task_service::get_task(pool, task_id).await.ok()
+        .and_then(|t| t.definition_of_done);
+    let dod_section = build_dod_section(&dod);
+
     let planner_prompt = format!(
         "あなたは Planner Agent です。以下のタスクの実装計画を立ててください。\n\n\
         ## タスク\n\
         タイトル: {title}\n\
         説明: {description}\n\n\
+        {dod_section}\
         ## 指示\n\
         1. コードベースを分析して、変更が必要なファイルを特定してください\n\
         2. 実装計画を以下の形式で出力してください:\n\
            - 変更ファイル一覧\n\
            - 各ファイルの変更内容\n\
            - テスト方針\n\
-        3. 計画のみ出力し、コード変更は行わないでください"
+        3. 計画のみ出力し、コード変更は行わないでください\n\
+        4. 完了条件がある場合は、すべての条件を満たす計画にしてください"
     );
 
     let plan_result = match run_claude_with_retry(&planner_prompt, &wt_path, timeout::PLANNER_SECS).await {
@@ -290,6 +307,11 @@ pub async fn run_planning_phase(
         format!("## ヒアリング回答\n{hearing_context}\n")
     };
 
+    // DoD 取得
+    let dod = task_service::get_task(pool, task_id).await.ok()
+        .and_then(|t| t.definition_of_done);
+    let dod_section = build_dod_section(&dod);
+
     let planner_prompt = match proposal_type {
         "investigation" => format!(
             "あなたは Planner Agent です。以下の調査タスクの調査計画を立ててください。\n\n\
@@ -297,6 +319,7 @@ pub async fn run_planning_phase(
             タイトル: {title}\n\
             説明: {description}\n\n\
             {hearing_section}\
+            {dod_section}\
             ## 指示\n\
             1. コードベースを分析して、調査対象のファイルや領域を特定してください\n\
             2. 調査計画を以下の形式で出力してください:\n\
@@ -316,6 +339,7 @@ pub async fn run_planning_phase(
             タイトル: {title}\n\
             説明: {description}\n\n\
             {hearing_section}\
+            {dod_section}\
             ## 指示\n\
             1. タスク内容を分析して、必要な GitHub 操作（Issue クローズ/作成/ラベル整理等）を特定してください\n\
             2. 操作計画を以下の形式で出力してください:\n\
@@ -335,6 +359,7 @@ pub async fn run_planning_phase(
             タイトル: {title}\n\
             説明: {description}\n\n\
             {hearing_section}\
+            {dod_section}\
             ## 指示\n\
             1. コードベースを分析して、変更が必要なファイルを特定してください\n\
             2. 実装計画を以下の形式で出力してください:\n\
@@ -473,18 +498,25 @@ async fn run_coder_to_pr(
         format!("## ヒアリング回答\n{hearing_context}\n")
     };
 
+    // DoD 取得
+    let dod = task_service::get_task(pool, task_id).await.ok()
+        .and_then(|t| t.definition_of_done);
+    let dod_section = build_dod_section(&dod);
+
     let coder_prompt = format!(
         "あなたは Coder Agent です。以下の計画に基づいてコードを実装してください。\n\n\
         ## タスク\n\
         タイトル: {title}\n\
         説明: {description}\n\n\
         {hearing_section}\
+        {dod_section}\
         ## 実装計画\n\
         {plan}\n\n\
         ## 指示\n\
         - 計画に従って必要なコード変更を実装してください\n\
         - テストコードも追加してください\n\
-        - 変更は最小限に留めてください"
+        - 変更は最小限に留めてください\n\
+        - 完了条件がある場合は、すべての条件を満たすように実装してください"
     );
 
     let coder_result = match run_claude_autonomous_with_retry(&coder_prompt, wt_path, timeout::CODER_SECS).await {
@@ -512,14 +544,17 @@ async fn run_coder_to_pr(
             log(pool, session_id, "reviewer", iteration, "info", &format!("レビュー iteration {iteration}")).await;
 
             let diff = get_diff_output(wt_path).await;
+            let reviewer_dod = build_dod_section(&dod);
             let reviewer_prompt = format!(
                 "あなたは Reviewer Agent です。以下の diff をレビューしてください。\n\n\
                 ## タスク\n\
                 {description}\n\n\
+                {reviewer_dod}\
                 ## Diff\n\
                 ```\n{diff}\n```\n\n\
                 ## 指示\n\
                 - コード品質、バグ、セキュリティの観点でレビュー\n\
+                - 完了条件がある場合は、すべての条件が満たされているか確認\n\
                 - 最終行に必ず VERDICT: APPROVE または VERDICT: REQUEST_CHANGES を出力"
             );
 
@@ -771,6 +806,8 @@ pub async fn run_revision_phase(
         Err(_) => return,
     };
     let plan = task.plan.unwrap_or_default();
+    let dod = task.definition_of_done;
+    let dod_section = build_dod_section(&dod);
     let hearing_context = task_service::get_hearing_context(pool, task_id).await.unwrap_or_default();
 
     // === Coder (修正指示付き) ===
@@ -789,6 +826,7 @@ pub async fn run_revision_phase(
         タイトル: {title}\n\
         説明: {description}\n\n\
         {hearing_section}\
+        {dod_section}\
         ## 元の実装計画\n\
         {plan}\n\n\
         ## 修正依頼\n\
@@ -796,7 +834,8 @@ pub async fn run_revision_phase(
         ## 指示\n\
         - 上記の修正依頼に基づいて必要なコード変更を実装してください\n\
         - これは既存 PR への追加修正です\n\
-        - 修正依頼の内容に集中し、余計な変更は避けてください"
+        - 修正依頼の内容に集中し、余計な変更は避けてください\n\
+        - 完了条件がある場合は、すべての条件を満たすように修正してください"
     );
 
     let coder_result = match claude_cli::run_claude_autonomous(&coder_prompt, &wt_path, 1500).await {
@@ -823,17 +862,20 @@ pub async fn run_revision_phase(
         log(pool, session_id, "reviewer", iteration, "info", &format!("修正レビュー iteration {iteration}")).await;
 
         let diff = get_diff_output(&wt_path).await;
+        let reviewer_dod = build_dod_section(&dod);
         let reviewer_prompt = format!(
             "あなたは Reviewer Agent です。以下の diff をレビューしてください。\n\n\
             ## タスク\n\
             {description}\n\n\
             ## 修正依頼\n\
             {instructions}\n\n\
+            {reviewer_dod}\
             ## Diff\n\
             ```\n{diff}\n```\n\n\
             ## 指示\n\
             - コード品質、バグ、セキュリティの観点でレビュー\n\
             - 修正依頼の内容が適切に反映されているか確認\n\
+            - 完了条件がある場合は、すべての条件が満たされているか確認\n\
             - 最終行に必ず VERDICT: APPROVE または VERDICT: REQUEST_CHANGES を出力"
         );
 

--- a/backend/src/scanner/analyzer.rs
+++ b/backend/src/scanner/analyzer.rs
@@ -920,7 +920,8 @@ fn build_scan_prompt(
       "description": "何をなぜやるか",
       "priority": "high|medium|low",
       "proposal_type": "development|improvement|investigation|operation",
-      "issue_number": null
+      "issue_number": null,
+      "definition_of_done": "- [ ] 条件1\n- [ ] 条件2\n- [ ] 条件3"
     }}
   ],
   "improvement_suggestions": [
@@ -933,6 +934,7 @@ fn build_scan_prompt(
 }}
 
 ルール:
+- **完了条件 (DoD) 必須**: 各タスクには definition_of_done をチェックリスト形式（`- [ ] 条件`）で必ず含めること。完了時にすべてチェックが入る具体的・検証可能な条件を3〜5項目記述する
 - **1タスク = 1PR**: タスクは1つのPRで完結する粒度にすること。複数PRが必要な規模のタスクは分割して提案する
 - 大きなリファクタリングや複数ファイルにまたがる変更も、論理的に独立した単位に分割する
 - ユーザーは Issue に簡単なバグ・改善を書いているので、それをタスク化する

--- a/frontend/src/app/tasks/[id]/page.tsx
+++ b/frontend/src/app/tasks/[id]/page.tsx
@@ -178,6 +178,27 @@ export default function TaskDetailPage({
         )}
       </div>
 
+      {/* ─── Definition of Done ─── */}
+      {task.definition_of_done && (
+        <div className="mb-5 rounded-lg border border-gh-border bg-gh-surface/50 overflow-hidden">
+          <button
+            onClick={() => {
+              const el = document.getElementById("dod-body");
+              if (el) el.classList.toggle("hidden");
+            }}
+            className="w-full flex items-center justify-between px-4 py-2 text-sm font-medium text-gh-text-secondary hover:bg-gh-overlay transition cursor-pointer"
+          >
+            <span>完了条件 (Definition of Done)</span>
+            <svg className="w-4 h-4 text-gh-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div id="dod-body" className="px-4 py-3 border-t border-gh-border/50">
+            <DoDChecklist dod={task.definition_of_done} />
+          </div>
+        </div>
+      )}
+
       {error && <div className="text-gh-red mb-4 text-sm">{error}</div>}
 
       {/* ─── Action Buttons ─── */}
@@ -640,6 +661,40 @@ function ActionButton({
     >
       {children}
     </button>
+  );
+}
+
+function DoDChecklist({ dod }: { dod: string }) {
+  const lines = dod.split("\n").filter((l) => l.trim().length > 0);
+  return (
+    <ul className="space-y-1">
+      {lines.map((line, i) => {
+        const trimmed = line.trim();
+        const isChecked = trimmed.startsWith("- [x]") || trimmed.startsWith("- [X]");
+        const isCheckbox = isChecked || trimmed.startsWith("- [ ]");
+        const text = isCheckbox ? trimmed.slice(5).trim() : trimmed;
+        return (
+          <li key={i} className="flex items-start gap-2 text-sm">
+            {isCheckbox ? (
+              <span className={`mt-0.5 w-4 h-4 shrink-0 rounded border ${
+                isChecked
+                  ? "bg-gh-green/20 border-gh-green text-gh-green flex items-center justify-center"
+                  : "border-gh-border"
+              }`}>
+                {isChecked && (
+                  <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </span>
+            ) : (
+              <span className="mt-0.5 w-4 shrink-0 text-gh-text-muted">•</span>
+            )}
+            <span className={isChecked ? "text-gh-text-muted line-through" : "text-gh-text-secondary"}>{text}</span>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 

--- a/frontend/src/components/ScanResultPanel.tsx
+++ b/frontend/src/components/ScanResultPanel.tsx
@@ -253,6 +253,24 @@ function TaskProposalCard({
           <p className="text-xs text-gh-text-secondary line-clamp-2">
             {task.description}
           </p>
+          {task.definition_of_done && (
+            <details className="mt-1.5">
+              <summary className="text-[10px] text-gh-text-muted cursor-pointer hover:text-gh-text-secondary">
+                完了条件 (DoD)
+              </summary>
+              <ul className="mt-1 space-y-0.5 text-xs text-gh-text-secondary">
+                {task.definition_of_done.split("\n").filter(l => l.trim()).map((line, i) => {
+                  const text = line.trim().replace(/^- \[[ xX]\] /, "");
+                  return (
+                    <li key={i} className="flex items-start gap-1.5">
+                      <span className="mt-0.5 w-3 h-3 shrink-0 rounded border border-gh-border" />
+                      <span>{text}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </details>
+          )}
         </div>
         {isActionable && (
           <div className="flex gap-1.5 shrink-0">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -100,6 +100,7 @@ export function createTask(body: {
   title: string;
   description: string;
   priority?: string;
+  definition_of_done?: string;
 }) {
   return request<{ data: import("@/types").Task }>("/api/tasks", {
     method: "POST",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -64,6 +64,7 @@ export interface Task {
   merge_status: "pending" | "merged" | "conflict" | "failed" | null;
   merge_attempted_at: string | null;
   revision_count: number;
+  definition_of_done: string | null;
 }
 
 export interface ExecutionSession {


### PR DESCRIPTION
## タスク
前スプリントでworktreeロックエラーにより失敗したタスクの再実行。デプロイ反映済みを確認した上で実施する。タスク作成時にDoD入力を必須とし、完了判定の品質を向上させる。

## 計画
十分な情報が集まりました。実装計画を出力します。

---

# 実装計画: タスク定義に完了条件 (Definition of Done) を必須化

## 変更ファイル一覧

| # | ファイル | 変更内容 |
|---|---------|---------|
| 1 | `backend/migrations/20260321000000_definition_of_done.sql` | **新規** — tasksテーブルにカラム追加 |
| 2 | `backend/src/domains/tasks/model.rs` | Task構造体 + DTO に `definition_of_done` 追加 |
| 3 | `backend/src/domains/tasks/service.rs` | 全SQL文に `definition_of_done` 追加 (SELECT/INSERT/UPDATE) |
| 4 | `backend/src/domains/tasks/handler.rs` | `execute_issue` でIssue本文からDoD自動抽出 |
| 5 | `backend/src/domains/scans/model.rs` | `TaskProposal` に `definition_of_done` 追加 |
| 6 | `backend/src/domains/scans/service.rs` | `TASK_COLS` + `create_tasks_from_proposals` に DoD 追加 |
| 7 | `backend/src/scanner/analyzer.rs` | `build_scan_prompt` の出力JSONスキーマに DoD 追加 |
| 8 | `backend/src/executor/pipeline.rs` | 全Agent プロンプト (Planner/Coder/Reviewer) に DoD セクション追加 |
| 9 | `frontend/src/types/index.ts` | `Task` インターフェースに `definition_of_done` 追加 |
| 10 | `frontend/src/lib/api.ts` | `createTask` 関数に `definition_of_done` パラメータ追加 |
| 11 | `frontend/src/app/tasks/[id]/page.tsx` | タスク詳細画面に DoD チェックリスト表示 |
| 12 | `frontend/src/components/ScanResultPanel.tsx` | スキャン結果のタスク一覧に DoD 表示 |

---

## 各ファイルの変更内容

### 1. `backend/migrations/20260321000000_definition_of_done.sql` (新規)

```sql
ALTER TABLE tasks ADD COLUMN definition_of_done TEXT;
```

既存データは NULL 許容。新規作成時に各経路でバリデーションを実施。

### 2. `backend/src/domains/tasks/model.rs`

- **Task 構造体** (line 65): `pub definition_of_done: Option<String>` を `revision_count` の後に追加
- **CreateTaskRequest** (line 79-85): `pub definition_of_done: Option<String>` 追加
- **UpdateTaskRequest** (line 88-92): `pub definition_of_done: Option<String>` 追加
- **ExecuteIssueRequest** (line 141-147): `pub definition_of_done: Option<String>` 追加（フロントエンドから明示的に渡す場合のフォールバック用）

### 3. `backend/src/domains/tasks/service.rs`

全 SELECT 文のカラム列挙に `definition_of_done` を追加（計12箇所のSQL文）:
- `list_tasks()` — 4パターンの SELECT (line 10-76)
- `get_task()` — SELECT (line 82-85)
- `create_task()` — INSERT + RETURNING (line 105-110): INSERTカラムにも追加、`$6` で bind
- `create_task_from_issue()` — INSERT + RETURNING (line 131-136): 引数に `definition_of_done: &str` 追加、`$8` で bind
- `update_task()` — UPDATE + RETURNING (line 151-159): `definition_of_done = COALESCE($5, definition_of_done)` 追加
- `approve_task()`, `cancel_task()`, `approve_plan()`, `reject_plan()`, `request_revision()` — RETURNING句のみ追加
- `update_task_execution()` — RETURNING句のみ追加
- `list_mergeable_tasks()` — SELECT文のみ追加

### 4. `backend/src/domains/tasks/handler.rs`

**`execute_issue()` (line 319-392):**
- Issue本文 (`issue.body`) から DoD を自動抽出する関数 `extract_dod_from_issue()` を追加
- 抽出ロジック: Issue本文から以下のパターンを検索
  - `## Definition of Done` / `## DoD` / `## 完了条件` / `## Acceptance Criteria` セクション
  - チェックリスト形式 (`- [ ]` / `- [x]`) のリスト
  - 見つからない場合は Issue のタイトル+説明から「このタスクが完了したと言えるための条件」としてフォールバックテキストを生成（例: `- [ ] {issue.title} が実装されている`）
- `create_task_from_issue()` 呼び出し時に `definition_of_done` を渡す

**`create_task()` (line 37-44):**
- `CreateTaskRequest` に `definition_of_done` が含まれるので、service層にそのまま渡す（手動作成経路）

### 5. `backend/src/domains/scans/model.rs`

**`TaskProposal` (line 31-39):**
- `pub definition_of_done: Option<String>` 追加

### 6. `backend/src/domains/scans/service.rs`

- **`TASK_COLS` 定数** (line 11-14): `definition_of_done` 追加
- **`create_tasks_from_proposals()`** (line 150-168): INSERT文に `definition_of_done` カラムと `$10` bind を追加、`proposal.definition_of_done` を渡す

### 7. `backend/src/scanner/analyzer.rs`

**`build_scan_prompt()` (line 883-945):**
- 出力JSONスキーマの `task_proposals` に `definition_of_done` フィールドを追加:
```json
"definition_of_done": "- [ ] 条件1\n- [ ] 条件2\n- [ ] 条件3"
```
- ルールに追加: 「各タスクには definition_of_done をチェックリスト形式（`- [ ] 条件`）で必ず含めること。完了時にすべてチェックが入る具体的・検証可能な条件を3〜5項目記述する」

### 8. `backend/src/executor/pipeline.rs`

DoDをDBから取得してプロンプトに注入する。各パイプライン関数で `task_service::get_task()` を呼び、`task.definition_of_done` を取得。

**Planner プロンプト（3箇所）:**
- `run_pipeline()` (line 105-117): DoD セクション追加
- `run_planning_phase()` の3パターン (line 293-351): DoD セクション追加

追加するセクション:
```
## 完了条件 (Definition of Done)
{definition_of_done}

上記の完了条件をすべて満たす実装計画を立ててください。
```

**Coder プロンプト（2箇所）:**
- `run_coder_to_pr()` (line 476-488): DoD セクション追加
- `run_revision_phase()` (line 786-800): DoD セクション追加

追加するセクション:
```
## 完了条件 (Definition of Done)
{definition_of_done}

すべての完了条件を満たすように実装してください。
```

**Reviewer プロンプト（2箇所）:**
- `run_coder_to_pr()` (line 515-524): DoD セクション追加
- `run_revision_phase()` (line 826-838): DoD セクション追加

追加するセクション:
```
## 完了条件 (Definition of Done)
{definition_of_done}

レビュー時にすべての完了条件が満たされているか確認してください。
```

**DoDの受け渡し方法:**
- `run_pipeline` / `run_hearing_phase` / `run_planning_phase` / `run_execution_phase` の各関数シグネチャには変更を加えず、関数内で `task_service::get_task(pool, task_id)` を呼んで `task.definition_of_done` を取得する（既にDBから読める状態）
- DoDがNone/空の場合は「（完了条件は未設定）」をフォールバック表示

### 9. `frontend/src/types/index.ts`

**Task インターフェース** (line 36-67):
- `definition_of_done: string | null;` を `revision_count` の後に追加

### 10. `frontend/src/lib/api.ts`

**`createTask()`** (line 97-108):
- 引数の型に `definition_of_done?: string` 追加

### 11. `frontend/src/app/tasks/[id]/page.tsx`

- タスク詳細画面の description 表示の下に DoD チェックリスト表示セクションを追加
- `definition_of_done` が存在する場合、各行を `- [ ]` / `- [x]` パターンでパースし、チェックリストとして表示（読み取り専用）
- `Accordion` コンポーネントで「完了条件」として折りたたみ表示

### 12. `frontend/src/components/ScanResultPanel.tsx`

- スキャン提案結果のタスク一覧表示に DoD を追加表示（展開時に確認可能）

---

## テスト方針

1. **マイグレーション確認**: カラム追加後、既存データが影響を受けないこと（NULL許容）
2. **API手動テスト**:
   - `POST /api/tasks` で `definition_of_done` を含むリクエストが正常に処理される
   - `GET /api/tasks/{id}` で `definition_of_done` が返却される
   - `PUT /api/tasks/{id}` で `definition_of_done` が更新できる
3. **Issue実行テスト**: チェックリスト付きGitHub Issueから `execute_issue` を実行し、DoDが自動抽出される
4. **パイプライン確認**: 実行ログでPlanner/Coder/ReviewerプロンプトにDoDが含まれていることを確認
5. **ビルド確認**: `cargo build` + `npm run build` が通ること
6. **フロントエンド確認**: タスク詳細画面でDoDが正しく表示される

---

## 実装順序

1. マイグレーション → モデル → サービス → ハンドラ (バックエンド基盤)
2. スキャンモデル → スキャンサービス → スキャンプロンプト (スキャン経路)
3. パイプラインプロンプト (実行経路)
4. フロントエンド型 → API → UI
